### PR TITLE
Raw label parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,22 @@ Tools and tutorials for the OpenMIC-2018 dataset.
 [![Build Status](https://travis-ci.com/cosmir/openmic-2018.svg?branch=master)](https://travis-ci.com/cosmir/openmic-2018)
 
 [![Coverage Status](https://coveralls.io/repos/github/cosmir/openmic-2018/badge.svg?branch=master)](https://coveralls.io/github/cosmir/openmic-2018?branch=master)
+
+
+## Errata
+
+When initially collecting data, ten audio files were corrupted due to [an issue](https://github.com/mdeff/fma/issues/27) in the source FMA dataset:
+
+```python
+'071826', '071827', '087435', '095253', '095259',
+'095263', '102144', '113025', '113604', '138485'
+```
+
+Of the 41k responses obtained, only _three_ resulted in erroneous labels by annotators.
+The following rows have been manually corrected:
+
+Sample Key | Instrument | True Label
+--- | --- | ---
+095253_134400 | piano | yes
+095263_96000 | mallet percussion | yes
+113025_99840 | trumpet | yes

--- a/scripts/parse_raw_results.py
+++ b/scripts/parse_raw_results.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding: utf8
+'''Script to parse raw annotation results into a sparse label collection.
+
+Example
+-------
+$ ./scripts/parse_raw_results.py "path/to/dir/*.csv" sparse-labels.csv
+
+'''
+from __future__ import print_function
+
+import argparse
+import glob
+import os
+import pandas as pd
+import sys
+import tqdm
+
+YN_MAP = {'no': -1, 'yes': 1}
+COLUMNS = ['sample_key', 'instrument', 'relevance', 'num_responses']
+CONF_COL = 'does_this_recording_contain_{}:confidence'
+CONTAIN_COL = 'does_this_recording_contain_{}'
+
+
+def parse_one(row):
+    sign = YN_MAP[row[CONTAIN_COL.format(row.instrument)]]
+    conf = row[CONF_COL.format(row.instrument)] / 2.0
+    proba = 0.5 + sign * conf
+    return dict(sample_key=row.sample_key, instrument=row.instrument,
+                relevance=proba, num_responses=row._trusted_judgments)
+
+
+def main(csv_files, output_filename):
+    records = []
+    for csv_file in tqdm.tqdm(csv_files):
+        records += pd.read_csv(csv_file).apply(parse_one, axis=1).values.tolist()
+
+    df = pd.DataFrame.from_records(records)
+    print('Loaded {} records'.format(len(df)))
+
+    df.sort_values(by='sample_key', inplace=True)
+    df.to_csv(output_filename, columns=COLUMNS, index=None)
+    return os.path.exists(output_filename)
+
+
+def process_args(args):
+
+    parser = argparse.ArgumentParser(description='Raw annotation results parser')
+
+    parser.add_argument('csv_pattern', type=str, action='store',
+                        help='Glob-style file pattern for picking up CSV files.')
+    parser.add_argument(dest='output_filename', type=str, action='store',
+                        help='Output filename for writing the sparse label CSV.')
+    return parser.parse_args(args)
+
+
+if __name__ == '__main__':
+    args = process_args(sys.argv[1:])
+
+    csv_files = glob.glob(args.csv_pattern)
+
+    success = main(csv_files, args.output_filename)
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
tooling to convert CSV results from CrowdFlower into a sparse label format. Introduces `num_responses` into the table, and bounds relevance values on `[0, 1]`. Histogram confirms that there's no relevance scores in the middle, e.g. no relevance values in `(0.25, 0.75)`:

![image](https://user-images.githubusercontent.com/926379/44679429-f0ba4680-aa08-11e8-8d37-c2ceac395d1d.png)


