### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains companion source code for working with the [OpenMIC-201
 
 If you use this dataset, please cite the following work:
 
-> Humphrey, Eric J., Durand, Simon, and McFee, Brian. "OpenMIC-2018: An Open Dataset for Multiple Instrument Recognition." in Proceedings of the 19th International Society for Music Information Retrieval Conference (ISMIR), 2018. [pdf](https://bmcfee.github.io/papers/ismir2018_openmic.pdf)
+> Humphrey, Eric J., Durand, Simon, and McFee, Brian. "OpenMIC-2018: An Open Dataset for Multiple Instrument Recognition." in Proceedings of the 19th International Society for Music Information Retrieval Conference (ISMIR), 2018. [pdf](https://zenodo.org/record/1492445#.XsPDCRMzZTY)
 
 
 ## Download the Dataset
@@ -49,7 +49,7 @@ openmic-2018/
     ..
 ```
 
-The `openmic-2018.npz` is a Python-friendly composite of the `vggish` features and the `openmic-2018-aggregated-labels.csv`. An example of how to train and evaluate a model is provided in a [tutorial notebook](http://tbd).
+The `openmic-2018.npz` is a Python-friendly composite of the `vggish` features and the `openmic-2018-aggregated-labels.csv`. An example of how to train and evaluate a model is provided in a [tutorial notebook](https://github.com/cosmir/openmic-2018/blob/master/examples/modeling-baseline.ipynb).
 
 
 ## Installing


### PR DESCRIPTION
The purpose of this PR is to update some of the links of the README.

The main one is the baseline notebook, that is currently set to `http://tbd`.
The minor one is to use an official link for the paper, especially since it is an open source link. If you prefer direct pdf format, we can use [this](https://archives.ismir.net/ismir2018/paper/000248.pdf). However, if you prefer to use the current one, no problem reverting that suggestion.

Let me know if that looks good to you.
